### PR TITLE
Add biocViews to description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ License: GPL-3
 Encoding: UTF-8
 Depends: R (>= 3.4.0), Rcpp, data.table
 LinkingTo: Rcpp, RcppArmadillo
+biocViews:
 Imports: 
     dplyr, 
     methods,


### PR DESCRIPTION
Adding biocViews: to the description allows the DESeq2 dependency to be installed automatically from Bioconductor.  Otherwise this happens:
```r
> devtools::install_github("immunogenomics/presto")
Downloading GitHub repo immunogenomics/presto@master
Skipping 1 packages not available: DESeq2
Installing 2 packages: DESeq2, RcppArmadillo
Error: Failed to install 'presto' from GitHub:
  (converted from warning) package ‘DESeq2’ is not available (for R version 3.6.3)
```