### PR TITLE
Change the 'slot' option in getassaydata to 'layer'. Slot was depreca…

### DIFF
--- a/R/wilcoxauc.R
+++ b/R/wilcoxauc.R
@@ -90,7 +90,7 @@ wilcoxauc.Seurat <- function(
     ...
 ) {
     requireNamespace("Seurat")
-    X_matrix <- Seurat::GetAssayData(X, assay = seurat_assay, slot = assay)
+    X_matrix <- Seurat::GetAssayData(X, assay = seurat_assay, layer = assay)
     if (is.null(group_by)) {
         y <- Seurat::Idents(X)
     } else {


### PR DESCRIPTION
'slot' option is deprecated as of Seurat v5, changing this to 'layer' instead.