### PR TITLE
Apply fix for deprecated SeuratObject code

### DIFF
--- a/R/wilcoxauc.R
+++ b/R/wilcoxauc.R
@@ -90,7 +90,7 @@ wilcoxauc.Seurat <- function(
     ...
 ) {
     requireNamespace("Seurat")
-    X_matrix <- Seurat::GetAssayData(X, assay = seurat_assay, slot = assay)
+    X_matrix <- Seurat::GetAssayData(X, assay = seurat_assay, layer = assay)
     if (is.null(group_by)) {
         y <- Seurat::Idents(X)
     } else {


### PR DESCRIPTION
This pull request makes a minor update to the `wilcoxauc.Seurat` function in `R/wilcoxauc.R`, changing the argument name from `slot` to `layer` when calling `Seurat::GetAssayData`. The slot parameter was broken with SeuratObject v5.3.0. and later, causing the original version of Presto to fail with the latest version of SeuratObject. This fix was originally submitted [as a PR](https://github.com/immunogenomics/presto/pull/44) to the original Presto but has not been merged as of March 17th, 2026.